### PR TITLE
fix(calendar): fix display position date-picker

### DIFF
--- a/scss/specifics/calendar/_calendar.scss
+++ b/scss/specifics/calendar/_calendar.scss
@@ -35,5 +35,5 @@ body.calendar {
 }
 
 calendar .week-switcher .date-picker-icon {
-  margin-left: 0;
+  margin-left: 0 !important;
 }


### PR DESCRIPTION
Add an '!important' statement where it was wrongly deleted.