### PR TITLE
fix(folderTree): #LOOL-59 remove horizontal scrollBar in folder tree display 

### DIFF
--- a/scss/specifics/lool-connector/_lool-connector.scss
+++ b/scss/specifics/lool-connector/_lool-connector.scss
@@ -29,6 +29,9 @@ body.lool {
         &-tree {
           max-height: 50vh;
           overflow-y: auto;
+          > ul {
+            box-sizing: border-box;
+          }
         }
       }
 


### PR DESCRIPTION
## Describe your changes
Prevent ul from being wider then its parent (nav) by adding a box sizing border-box. The fact that ul was wider added an unwanted hrizontal scrollbar to the nav.
## Checklist tests
Go in lool module (directly by typing it in url not in workspace).
## Issue ticket number and link
[LOOL-59](https://jira.support-ent.fr/browse/LOOL-59)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)